### PR TITLE
Allow using an alternative way to sample touch coordinates.

### DIFF
--- a/library/src/main/java/com/swordfish/radialgamepad/library/RadialGamePad.kt
+++ b/library/src/main/java/com/swordfish/radialgamepad/library/RadialGamePad.kt
@@ -639,7 +639,7 @@ class RadialGamePad @JvmOverloads constructor(
     }
 
     private fun extractFingersPositions(event: MotionEvent): Sequence<TouchUtils.FingerPosition> {
-        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+        return if (gamePadConfig.preferScreenTouchCoordinates && Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
             getLocationOnScreen(positionOnScreen)
             TouchUtils.extractRawFingersPositions(event, positionOnScreen[0], positionOnScreen[1])
         } else {

--- a/library/src/main/java/com/swordfish/radialgamepad/library/config/RadialGamePadConfig.kt
+++ b/library/src/main/java/com/swordfish/radialgamepad/library/config/RadialGamePadConfig.kt
@@ -27,11 +27,13 @@ import com.swordfish.radialgamepad.library.haptics.HapticConfig
  * @property secondaryDials List of configurations for the surrounding secondary dials
  * @property haptic Choose which effects will be performed
  * @property theme RadialGamePadTheme for the whole view
+ * @property preferScreenTouchCoordinates Use an alternative sampling methods for touch coordinates
  */
 data class RadialGamePadConfig(
     val sockets: Int,
     val primaryDial: PrimaryDialConfig,
     val secondaryDials: List<SecondaryDialConfig>,
     val haptic: HapticConfig = HapticConfig.PRESS,
-    val theme: RadialGamePadTheme = RadialGamePadTheme()
+    val theme: RadialGamePadTheme = RadialGamePadTheme(),
+    val preferScreenTouchCoordinates: Boolean = false
 )


### PR DESCRIPTION
This can be used as a workaround to Android 13 touch issues.